### PR TITLE
Add AstroDogex token folder

### DIFF
--- a/blockchains/smartchain/assets/blockchains/smartchain/assets/0xA797801ed1F172be53A92F2aD3D13810B5E3b6F3/dummy.txt
+++ b/blockchains/smartchain/assets/blockchains/smartchain/assets/0xA797801ed1F172be53A92F2aD3D13810B5E3b6F3/dummy.txt
@@ -1,0 +1,1 @@
+Create folder for AstroDogex


### PR DESCRIPTION
Creating a folder for AstroDogex (ADGX) token on BSC to add logo and info.
Contract address: 0xA797801ed1F172be53A92F2aD3D13810B5E3b6F3